### PR TITLE
Added occupancy data to spaces in Edwaard Boyle and Laidlaw

### DIFF
--- a/_config_render.yml
+++ b/_config_render.yml
@@ -11,7 +11,7 @@ environment: development
 baseurl: ""
 url: "https://dev.spacefinder.leeds.ac.uk"
 host: "localhost"
-google_analytics: ""
+#google_analytics: ""
 photo_dir: "/assets/photos/"
 lang: "en"
 dc:

--- a/_config_render.yml
+++ b/_config_render.yml
@@ -7,7 +7,7 @@ description: >-
   includes detailed descriptions of each space, filters
   based on space characteristics, and  navigation via a
   map.
-environment: production
+environment: development
 baseurl: ""
 url: "https://dev.spacefinder.leeds.ac.uk"
 host: "localhost"

--- a/_config_render.yml
+++ b/_config_render.yml
@@ -11,7 +11,7 @@ environment: development
 baseurl: ""
 url: "https://dev.spacefinder.leeds.ac.uk"
 host: "localhost"
-google_analytics: "G-6LHKST5028"
+google_analytics: ""
 photo_dir: "/assets/photos/"
 lang: "en"
 dc:

--- a/_includes/javascript/templates.js
+++ b/_includes/javascript/templates.js
@@ -188,7 +188,7 @@ function updateOccupancy() {
 						if ( pco > 100 ) {
 							pco = 100;
                         }
-                        sdo.innerHTML = 'There are currently <strong>'+data[lib]+'</strong> users in the library which has a seating capacity of <strong>'+so[lib].capacity+'</strong>';
+                        sdo.innerHTML = 'There are currently <strong>'+data[lib]+'</strong> users in the library which has a seating capacity of approximately <strong>'+so[lib].capacity+'</strong>';
 					});
 				} else {
                     splog("No occupancy data for "+lib);

--- a/_includes/javascript/templates.js
+++ b/_includes/javascript/templates.js
@@ -1,7 +1,7 @@
 /**
  * Templates used to render spaces in the list.
  * 
- * Two fundtions should be defined in this file:
+ * Two functions should be defined in this file:
  * - getSpaceHTML - assembles HTML for the list view (short) and returns a HTML Element
  * - getAdditionalInfo - assembles HTML for expanded view and returns an HTML String
  */
@@ -153,3 +153,50 @@ function getClassList( space ) {
     }
     return classList;
 }
+
+/**
+ * Gets occupancy data for two spaces
+ */
+function updateOccupancy() {
+    let options = {
+        url: "https://resources.library.leeds.ac.uk/occupancy.json",
+        key: "libraryOccupancy",
+        expires: 0.015,
+        callback: function( data ) {
+			let so = {
+				"Edward Boyle": {
+					"spaces": [71,72,73,74],
+					"capacity": 500
+				},
+				"Laidlaw": {
+				    "spaces": [78,79,80,81,82],
+					"capacity": 600
+    			}
+			};
+			for( lib in so ) {
+				if ( data.hasOwnProperty( lib ) ) {
+					so[lib].spaces.forEach( id => {
+						let sdo = document.querySelector( '#space' + id + ' .space-details p.occupancy' );
+						if ( sdo == null ) {
+							sdo = document.createElement( 'p' );
+							sdo.classList.add( 'occupancy', 'icon-user' );
+							document.querySelector( '#space' + id + ' .space-details' ).appendChild( sdo );
+						}
+						let pco = Math.floor( ( data[lib] / so[lib].capacity ) * 100 );
+						if ( pco > 100 ) {
+							pco = 100;
+                        }
+                        sdo.innerHTML = 'There are currently <strong>'+data[lib]+'</strong> users in the library which has a seating capacity of <strong>'+so[lib].capacity+'</strong>';
+					});
+				}
+			}
+        }
+    }
+    getJSON( options );
+}
+document.addEventListener( 'DOMContentLoaded', () => {
+    document.addEventListener( 'spacesloaded', () => {
+        updateOccupancy();
+        setInterval( updateOccupancy, 5000 );
+    });
+});

--- a/_includes/javascript/templates.js
+++ b/_includes/javascript/templates.js
@@ -180,7 +180,6 @@ function updateOccupancy() {
         key: "libraryOccupancy",
         expires: 0.015,
         callback: function( data ) {
-            updateSpaceInfoWindowContent();
 			for( lib in spacefinder.occupancyData ) {
 				if ( data.hasOwnProperty( lib ) ) {
                     splog( 'Updating occupancy for spaces in '+lib+' to '+data[lib], 'templates.js' );
@@ -202,6 +201,7 @@ function updateOccupancy() {
                     splog("No occupancy data for "+lib);
                 }
 			}
+            updateSpaceInfoWindowContent();
         }
     }
     getJSON( options );

--- a/_includes/javascript/templates.js
+++ b/_includes/javascript/templates.js
@@ -180,6 +180,7 @@ function updateOccupancy() {
         key: "libraryOccupancy",
         expires: 0.015,
         callback: function( data ) {
+            updateSpaceInfoWindowContent();
 			for( lib in spacefinder.occupancyData ) {
 				if ( data.hasOwnProperty( lib ) ) {
                     splog( 'Updating occupancy for spaces in '+lib+' to '+data[lib], 'templates.js' );
@@ -206,21 +207,32 @@ function updateOccupancy() {
     getJSON( options );
 }
 /**
- * Overwrite function for map infoWindows to display occupancy data
+ * update popups to display occupancy data
  */
-var origGetSpaceInfoWindowContent = getSpaceInfoWindowContent;
-function getSpaceInfoWindowContent( space ) {
-    let content = origGetSpaceInfoWindowContent( space );
-    splog( spacefinder.occupancyData, 'templates.js' );
-    for( lib in spacefinder.occupancyData ) {
-        if ( spacefinder.occupancyData[lib].spaces.indexOf( space.id ) !== -1 && spacefinder.occupancyData[lib].occupancy > 0 ) {
-            let occMsg = '<p class="occupancy icon-user">There are currently <strong>'+spacefinder.occupancyData[lib].occupancy+'</strong> people in the library which has a seating capacity of approximately <strong>'+spacefinder.occupancyData[lib].capacity+'</strong></p>';
-            content.replace('<button', occMsg+'<button');
+function updateSpaceInfoWindowContent() {
+    for ( let i = 0; i < spacefinder.spaces.length; i++ ) {
+        if ( spacefinder.spaces[i].lat && spacefinder.spaces[i].lng ) {
+            for( lib in spacefinder.occupancyData ) {
+                if ( spacefinder.occupancyData[lib].spaces.indexOf( spacefinder.spaces[i].id ) !== -1 && spacefinder.occupancyData[lib].occupancy > 0 ) {
+                    let info = [];
+                    info.push( space.space_type );
+                    if ( space.floor !== '' ) {
+                        info.push( space.floor );
+                    }
+                    if ( space.building !== '' ) {
+                        info.push( space.building );
+                    }
+                    let content = '<div class="spaceInfoWindow"><h3>'+space.title+'</h3>';
+                    content += '<p class="info">' + info.join(', ') + '</p>';
+                    content += '<p class="description">' + space.description + '</p>';
+                    content += '<p class="occupancy icon-user">There are currently <strong>'+spacefinder.occupancyData[lib].occupancy+'</strong> people in the library which has a seating capacity of approximately <strong>'+spacefinder.occupancyData[lib].capacity+'</strong></p>';
+                    content += '<button class="show-list">More info&hellip;</button></div>';
+                    spacefinder.spaces[i].marker.setPopupContent( content );
+                }
+            }
         }
     }
-    return content;
 }
-
 document.addEventListener( 'DOMContentLoaded', () => {
     document.addEventListener( 'spacesloaded', () => {
         setInterval( updateOccupancy, 5000 );

--- a/_includes/javascript/templates.js
+++ b/_includes/javascript/templates.js
@@ -211,6 +211,7 @@ function updateOccupancy() {
 var origGetSpaceInfoWindowContent = getSpaceInfoWindowContent;
 function getSpaceInfoWindowContent( space ) {
     let content = origGetSpaceInfoWindowContent( space );
+    splog( spacefinder.occupancyData, 'templates.js' );
     for( lib in spacefinder.occupancyData ) {
         if ( spacefinder.occupancyData[lib].spaces.indexOf( space.id ) !== -1 && spacefinder.occupancyData[lib].occupancy > 0 ) {
             let occMsg = '<p class="occupancy icon-user">There are currently <strong>'+spacefinder.occupancyData[lib].occupancy+'</strong> people in the library which has a seating capacity of approximately <strong>'+spacefinder.occupancyData[lib].capacity+'</strong></p>';

--- a/_includes/javascript/templates.js
+++ b/_includes/javascript/templates.js
@@ -215,16 +215,16 @@ function updateSpaceInfoWindowContent() {
             for( lib in spacefinder.occupancyData ) {
                 if ( spacefinder.occupancyData[lib].spaces.indexOf( spacefinder.spaces[i].id ) !== -1 && spacefinder.occupancyData[lib].occupancy > 0 ) {
                     let info = [];
-                    info.push( space.space_type );
-                    if ( space.floor !== '' ) {
-                        info.push( space.floor );
+                    info.push( spacefinder.spaces[i].space_type );
+                    if ( spacefinder.spaces[i].floor !== '' ) {
+                        info.push( spacefinder.spaces[i].floor );
                     }
-                    if ( space.building !== '' ) {
-                        info.push( space.building );
+                    if ( spacefinder.spaces[i].building !== '' ) {
+                        info.push( spacefinder.spaces[i].building );
                     }
-                    let content = '<div class="spaceInfoWindow"><h3>'+space.title+'</h3>';
+                    let content = '<div class="spaceInfoWindow"><h3>'+spacefinder.spaces[i].title+'</h3>';
                     content += '<p class="info">' + info.join(', ') + '</p>';
-                    content += '<p class="description">' + space.description + '</p>';
+                    content += '<p class="description">' + spacefinder.spaces[i].description + '</p>';
                     content += '<p class="occupancy icon-user">There are currently <strong>'+spacefinder.occupancyData[lib].occupancy+'</strong> people in the library which has a seating capacity of approximately <strong>'+spacefinder.occupancyData[lib].capacity+'</strong></p>';
                     content += '<button class="show-list">More info&hellip;</button></div>';
                     spacefinder.spaces[i].marker.setPopupContent( content );

--- a/_includes/javascript/templates.js
+++ b/_includes/javascript/templates.js
@@ -191,7 +191,7 @@ function updateOccupancy() {
 							sdo.classList.add( 'occupancy', 'icon-user' );
 							document.querySelector( '#space' + id + ' .space-details' ).appendChild( sdo );
 						}
-						let pco = Math.floor( ( data[lib] / so[lib].capacity ) * 100 );
+						let pco = Math.floor( ( spacefinder.occupancyData[lib].occupancy / spacefinder.occupancyData[lib].capacity ) * 100 );
 						if ( pco > 100 ) {
 							pco = 100;
                         }

--- a/_includes/javascript/templates.js
+++ b/_includes/javascript/templates.js
@@ -191,7 +191,9 @@ function updateOccupancy() {
                         }
                         sdo.innerHTML = 'There are currently <strong>'+data[lib]+'</strong> users in the library which has a seating capacity of <strong>'+so[lib].capacity+'</strong>';
 					});
-				}
+				} else {
+                    console.log("No data for "+lib);
+                }
 			}
         }
     }

--- a/_includes/javascript/templates.js
+++ b/_includes/javascript/templates.js
@@ -155,7 +155,7 @@ function getClassList( space ) {
 }
 
 /**
- * Gets occupancy data for two spaces
+ * Gets occupancy data for two libraries
  */
 function updateOccupancy() {
     let options = {
@@ -163,6 +163,7 @@ function updateOccupancy() {
         key: "libraryOccupancy",
         expires: 0.015,
         callback: function( data ) {
+            console.log(data);
 			let so = {
 				"Edward Boyle": {
 					"spaces": [71,72,73,74],
@@ -182,6 +183,7 @@ function updateOccupancy() {
 							sdo.classList.add( 'occupancy', 'icon-user' );
 							document.querySelector( '#space' + id + ' .space-details' ).appendChild( sdo );
 						}
+                        console.log(sdo);
 						let pco = Math.floor( ( data[lib] / so[lib].capacity ) * 100 );
 						if ( pco > 100 ) {
 							pco = 100;

--- a/_includes/javascript/templates.js
+++ b/_includes/javascript/templates.js
@@ -167,11 +167,11 @@ function updateOccupancy() {
 			let so = {
 				"Edward Boyle": {
 					"spaces": [71,72,73,74],
-					"capacity": 500
+					"capacity": 1800
 				},
 				"Laidlaw": {
 				    "spaces": [78,79,80,81,82],
-					"capacity": 600
+					"capacity": 640
     			}
 			};
 			for( lib in so ) {

--- a/_includes/javascript/templates.js
+++ b/_includes/javascript/templates.js
@@ -200,7 +200,6 @@ function updateOccupancy() {
 }
 document.addEventListener( 'DOMContentLoaded', () => {
     document.addEventListener( 'spacesloaded', () => {
-        updateOccupancy();
         setInterval( updateOccupancy, 5000 );
     });
 });

--- a/_includes/javascript/templates.js
+++ b/_includes/javascript/templates.js
@@ -158,12 +158,12 @@ function getClassList( space ) {
  * Gets occupancy data for two libraries
  */
 function updateOccupancy() {
+    splog( 'updateOccupancy', 'templates.js' );
     let options = {
         url: "https://resources.library.leeds.ac.uk/occupancy.json",
         key: "libraryOccupancy",
         expires: 0.015,
         callback: function( data ) {
-            console.log(data);
 			let so = {
 				"Edward Boyle": {
 					"spaces": [71,72,73,74],
@@ -176,7 +176,7 @@ function updateOccupancy() {
 			};
 			for( lib in so ) {
 				if ( data.hasOwnProperty( lib ) ) {
-                    console.log(data[lib]);
+                    splog( 'Updating occupancy for spaces in '+lib+' to '+data[lib], 'templates.js' );
 					so[lib].spaces.forEach( id => {
 						let sdo = document.querySelector( '#space' + id + ' .space-details p.occupancy' );
 						if ( sdo == null ) {
@@ -184,7 +184,6 @@ function updateOccupancy() {
 							sdo.classList.add( 'occupancy', 'icon-user' );
 							document.querySelector( '#space' + id + ' .space-details' ).appendChild( sdo );
 						}
-                        console.log(sdo);
 						let pco = Math.floor( ( data[lib] / so[lib].capacity ) * 100 );
 						if ( pco > 100 ) {
 							pco = 100;
@@ -192,7 +191,7 @@ function updateOccupancy() {
                         sdo.innerHTML = 'There are currently <strong>'+data[lib]+'</strong> users in the library which has a seating capacity of <strong>'+so[lib].capacity+'</strong>';
 					});
 				} else {
-                    console.log("No data for "+lib);
+                    splog("No occupancy data for "+lib);
                 }
 			}
         }

--- a/_includes/javascript/templates.js
+++ b/_includes/javascript/templates.js
@@ -176,6 +176,7 @@ function updateOccupancy() {
 			};
 			for( lib in so ) {
 				if ( data.hasOwnProperty( lib ) ) {
+                    console.log(data[lib]);
 					so[lib].spaces.forEach( id => {
 						let sdo = document.querySelector( '#space' + id + ' .space-details p.occupancy' );
 						if ( sdo == null ) {

--- a/_sass/spaces.scss
+++ b/_sass/spaces.scss
@@ -63,7 +63,7 @@
             .occupancy {
                 padding: .3em 0;
                 &:before, strong {
-                    color: $opencolor;
+                    color: $color-brand--dark;
                 }
             }
         }

--- a/_sass/spaces.scss
+++ b/_sass/spaces.scss
@@ -1,0 +1,169 @@
+#listcontrols {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    border-bottom: 1px solid $filterbg;
+    p {
+        flex: 1;
+        margin: 1px 3px;
+        padding: .5rem;
+    }
+}
+#listfilters {
+    padding: .5rem;
+    border-bottom: 1px solid $filterbg;
+    .noresults {
+        padding: .5rem 0 .5rem 1rem;
+        position:relative;
+        &:before {
+            content: "!";
+            color: red;
+            position:absolute;
+            top: .5rem;
+            font-weight: bold;
+            left: 0;
+        }
+    }
+}
+#listcontent {
+    .list-space {
+        padding: 1rem .5rem;
+        border-bottom: 1px solid $separatorcolor;
+        &:after {
+            content: "";
+            display: block;
+            clear: both;
+        }
+        &.hidden {
+            display: none;
+        }
+        &.active {
+            background: $activespacebg;
+            .space-details {
+                .space-image {
+                    width: 100%;
+                    height: auto;
+                    float: none;
+                    margin: 0 0 1rem 0;
+                }
+            }
+        }
+        .space-details {
+            &:after {
+                content: "";
+                display: block;
+                clear: both;
+            }
+            .space-image {
+                width: 50%;
+                height: auto;
+                float: left;
+                margin: 0 1rem 1rem 0;
+            }
+            .occupancy {
+                padding: .3em 0;
+                &:before, strong {
+                    color: $opencolor;
+                }
+            }
+        }
+        h3 {
+            font-size: 1.4rem;
+            font-weight: normal;
+            padding-bottom: .3rem;
+            &:focus {
+                outline: 1px dotted $spacesubheadborder;
+            }
+        }
+        p.space-info {
+            font-weight: normal;
+            padding-bottom: .3rem;
+            display: flex;
+            flex-direction: row;
+            align-items: baseline;
+            gap: 1rem;
+            > span {
+                flex: 1;
+                &.space-type {
+                    font-size: 1.2rem;
+                    display: block;
+                    color: $highlighttextcolor;
+                    span.distance {
+                        display: block;
+                        color: $lighttextcolor;
+                        font-size: .9rem;
+                    }
+                }
+                &.address {
+                    max-width: 70%;
+                    color: $lighttextcolor;
+                    text-align: right;
+                    font-size: .9rem;
+                }
+            }
+        }
+        &[data-sortdistance=""] p.space-info > span.space-type span.distance {
+            display: none;
+        }
+        h4 {
+            font-size: 1.1rem;
+            font-weight: normal;
+            padding-bottom: .5rem 0;
+            background: $spacesubheadbg;
+            margin: .5rem 0;
+            border-top: 1px dotted $spacesubheadborder;
+            border-bottom: 1px dotted $spacesubheadborder;
+        }
+        ul.bulleticons {
+            list-style: none;
+            padding: 0;
+            li {
+                position: relative;
+                padding: .1rem 0 .1rem 2.5rem;
+                &:before {
+                    position: absolute;
+                    top: .25rem;
+                    left: 0.5rem;
+                }
+                &.icon-link {
+                    word-break: break-all;
+                }
+            }
+        }
+        &[data-openclass="open"] {
+            [data-openmsg-id],
+            li.today {
+                color: $opencolor;
+            }
+        }
+        &[data-openclass="opening-later"] {
+            [data-openmsg-id],
+            li.today {
+                color: $openingcolor;
+            }
+        }
+        &[data-openclass="open"] {
+            [data-openmsg-id],
+            li.today {
+                color: $closedcolor;
+            }
+        }
+        ul.opening-times {
+            list-style: none;
+            padding: 0;
+            li {
+                display: flex;
+                span.dayname {
+                    font-weight: bold;
+                    width: 25%;
+                    border-bottom: 1px solid $spacesubheadborder;
+                }
+                span.opening {
+                    width: 25%;
+                    text-align: right;
+                    border-bottom: 1px solid $spacesubheadborder;
+                }
+            }
+        }
+    }
+}

--- a/_sass/spaces.scss
+++ b/_sass/spaces.scss
@@ -1,3 +1,9 @@
+.occupancy {
+    padding: .3em 0;
+    &:before, strong {
+        color: $color-brand--dark;
+    }
+}
 #listcontrols {
     display: flex;
     flex-wrap: wrap;
@@ -59,12 +65,6 @@
                 height: auto;
                 float: left;
                 margin: 0 1rem 1rem 0;
-            }
-            .occupancy {
-                padding: .3em 0;
-                &:before, strong {
-                    color: $color-brand--dark;
-                }
             }
         }
         h3 {


### PR DESCRIPTION
A new service has been created to publish data about occupancy levels in the Edward Boyle and Laidlaw libraries. These changes integrate this data into spacefinder by adding a line under the description of each space affected to describe what the occupancy levels are. The same text is added to the map popups.

Some changes have also been made to the jekyll config file for the render-based site so it displays the development version with all debugging information.
